### PR TITLE
ci:自动删除已完成合并的分之

### DIFF
--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -7,23 +7,19 @@ jobs:
   delete-branch:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
+      - name: 检出代码
         uses: actions/checkout@v4
 
-      - name: set_env
+      - name: 设置环境变量
         run: |
           echo "BRANCH_NAME=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
           echo "PR_MERGED=${{ github.event.pull_request.merged }}" >> $GITHUB_ENV
 
-      - name: delete_branch
+      - name: 删除分支
         run: |
-          echo "PR事件分支：$BRANCH_NAME"
-          echo "PR是否已合并：$PR_MERGED"
-
-          # 如果PR已合并，则删除分支
           if [ "$PR_MERGED" = "true" ]; then
-            echo "正在删除分支 $BRANCH_NAME..."
-            git push origin --delete $BRANCH_NAME || true
+            echo "正在删除分支：$BRANCH_NAME"
+            git push origin --delete "$BRANCH_NAME" || true
           else
             echo "PR未合并，跳过删除分支操作。"
           fi

--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -1,0 +1,22 @@
+name: delete branch on close pr
+on: 
+  pull_request:
+    types: [closed]
+  
+jobs:
+  delete-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v4
+
+      - name: 删除分之
+        run: |
+          echo "PR事件分支：${{ github.event.pull_request.head.ref }}"
+          echo "PR是否已合并：${{ github.event.pull_request.merged }}"
+          # 如果PR已合并，则删除分支
+          if [ "${{ github.event.pull_request.merged }}" = "true" ]; then
+            git push origin --delete ${{ github.event.pull_request.head.ref }} || true
+          else
+            echo "PR未合并，跳过删除分支操作。"
+          fi

--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -7,16 +7,23 @@ jobs:
   delete-branch:
     runs-on: ubuntu-latest
     steps:
-      - name: 检出代码
+      - name: checkout
         uses: actions/checkout@v4
 
-      - name: 删除分之
+      - name: set_env
         run: |
-          echo "PR事件分支：${{ github.event.pull_request.head.ref }}"
-          echo "PR是否已合并：${{ github.event.pull_request.merged }}"
+          echo "BRANCH_NAME=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
+          echo "PR_MERGED=${{ github.event.pull_request.merged }}" >> $GITHUB_ENV
+
+      - name: delete_branch
+        run: |
+          echo "PR事件分支：$BRANCH_NAME"
+          echo "PR是否已合并：$PR_MERGED"
+
           # 如果PR已合并，则删除分支
-          if [ "${{ github.event.pull_request.merged }}" = "true" ]; then
-            git push origin --delete ${{ github.event.pull_request.head.ref }} || true
+          if [ "$PR_MERGED" = "true" ]; then
+            echo "正在删除分支 $BRANCH_NAME..."
+            git push origin --delete $BRANCH_NAME || true
           else
             echo "PR未合并，跳过删除分支操作。"
           fi


### PR DESCRIPTION
[![PR-93](https://badgen.net/badge/%E9%A2%84%E8%A7%88/PR-93/blue)](https://pr-93.company.com) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=ChinaGodMan&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

自动对已经合并的分之进行删除

### 变更类型

-   [x] 新功能
-   [x] QA

好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

CI:
- 添加了一个工作流程，在 pull request 合并后自动删除分支。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Adds a workflow that automatically deletes branches after their pull requests have been merged.

</details>