### PR TITLE
feat(twitter-media-downloader): 新增引用推文媒体选择功能

### DIFF
--- a/twitter-media-downloader/twitter-media-downloader.user.js
+++ b/twitter-media-downloader/twitter-media-downloader.user.js
@@ -551,8 +551,8 @@ const TMD = (function () {
             let user
             if (hasQuotedMedia) {
                 // 存在引用媒体，需要用户选择
-                let originalUser = `${json.core?.user_results?.result?.legacy?.name}@${json.core?.user_results?.result?.legacy?.screen_name})` || 'unknown'
-                let quotedUser = `${json.quoted_status_result?.result?.core?.user_results?.result?.legacy?.name} @${json.quoted_status_result?.result?.core?.user_results?.result?.legacy?.screen_name})` || 'unknown'
+                let originalUser = `${json.core?.user_results?.result?.legacy?.name} @${json.core?.user_results?.result?.legacy?.screen_name}`
+                let quotedUser = `${json.quoted_status_result?.result?.core?.user_results?.result?.legacy?.name} @${json.quoted_status_result?.result?.core?.user_results?.result?.legacy?.screen_name}`
 
                 let choice = await this.selectTweetDialog(originalUser, quotedUser)
                 if (!choice) {


### PR DESCRIPTION
[![PR-235](https://img.shields.io/badge/%E9%A2%84%E8%A7%88-PR--235-blue?logo=)](https://pr-235.company.com) ![Medium](https://img.shields.io/badge/PR_Size-Medium-yellow?logo=) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=ChinaGodMan&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

### 变更内容

当检测到推文包含引用推文且引用推文含有媒体时，弹出对话框让用户选择下载原始推文还是引用推文的媒体。

提升了对复杂推文结构的支持能力，并优化了用户体验。

### 相关问题

resolve #127 
resolve #199
resolve #212

### 变更类型

-   [x] 修复 Bug
-   [x] 新功能
-   [x] 代码优化
-   [ ] 文档更新
-   [ ] 其他（请描述）
-   [x] QA

### 测试情况

对包含和不包含引用媒体的推文进行了测试，工作正常

### 注意事项

无